### PR TITLE
feat: add noAdditionalProperties param to allow generating schemas where child objects are also strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ jobs:
 | `title` | Title of the schema | `''` | false |
 | `description` | Description of the schema | `''` | false |
 | `additionalProperties` | Additional properties allowed in the schema (bool) | `''` | false |
+| `noAdditionalProperties` | Additional properties allowed in the schema, including child objects (bool) | `''` | false |
 | `git-push` | If true it will commit and push the changes (ignored if `fail-on-diff` is set) | `false` | false |
 | `git-push-user-name` | If empty the name of the GitHub Actions bot will be used | `github-actions[bot]` | false |
 | `git-push-user-email` | If empty the no-reply email of the GitHub Actions bot will be used | `github-actions[bot]@users.noreply.github.com` | false |

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -158,7 +158,8 @@ describe('run function', () => {
       id: 'id',
       title: 'title',
       description: 'description',
-      additionalProperties: 'true'
+      additionalProperties: 'true',
+      noAdditionalProperties: 'true'
     }
 
     getInputMock.mockImplementation((inputName: string) => {
@@ -188,6 +189,7 @@ describe('run function', () => {
     expect(getInputMock).toHaveBeenCalledWith('title')
     expect(getInputMock).toHaveBeenCalledWith('description')
     expect(getInputMock).toHaveBeenCalledWith('additionalProperties')
+    expect(getInputMock).toHaveBeenCalledWith('noAdditionalProperties')
     expect(getInputMock).toHaveBeenCalledWith('git-push')
     expect(getInputMock).toHaveBeenCalledWith('git-push-user-name')
     expect(getInputMock).toHaveBeenCalledWith('git-push-user-email')

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,9 @@ inputs:
   additionalProperties:
     description: Additional properties allowed in the schema
     required: false
+  noAdditionalProperties:
+    description: Additional properties allowed in the schema, including child objects
+    required: false
   git-push:
     description: If true it will commit and push the changes (ignored if `fail-on-diff` is set)
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -34636,6 +34636,7 @@ async function run() {
         const title = core.getInput('title') || configFile.schemaRoot?.title;
         const description = core.getInput('description') || configFile.schemaRoot?.description;
         const additionalProperties = core.getInput('additionalProperties') || configFile.schemaRoot?.additionalProperties?.toString();
+        const noAdditionalProperties = core.getInput('noAdditionalProperties') || configFile.noAdditionalProperties?.toString();
         const gitPush = core.getInput('git-push');
         const gitPushUserName = core.getInput('git-push-user-name');
         const gitPushUserEmail = core.getInput('git-push-user-email');
@@ -34664,6 +34665,7 @@ async function run() {
             '-schemaRoot.title': title,
             '-schemaRoot.description': description,
             '-schemaRoot.additionalProperties': additionalProperties,
+            '-noAdditionalProperties': noAdditionalProperties,
             '-bundle': bundle,
             '-bundleRoot': bundleRoot,
             '-bundleWithoutID': bundleWithoutID,

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ interface SchemaConfig {
     description?: string
     additionalProperties?: boolean
   }
+  noAdditionalProperties?: boolean
   bundle?: boolean
   bundleRoot?: string
   bundleWithoutID?: boolean
@@ -55,6 +56,7 @@ export async function run(): Promise<void> {
     const title = core.getInput('title') || configFile.schemaRoot?.title
     const description = core.getInput('description') || configFile.schemaRoot?.description
     const additionalProperties = core.getInput('additionalProperties') || configFile.schemaRoot?.additionalProperties?.toString()
+    const noAdditionalProperties = core.getInput('noAdditionalProperties') || configFile.noAdditionalProperties?.toString()
     const gitPush = core.getInput('git-push')
     const gitPushUserName = core.getInput('git-push-user-name')
     const gitPushUserEmail = core.getInput('git-push-user-email')
@@ -88,6 +90,7 @@ export async function run(): Promise<void> {
       '-schemaRoot.title': title,
       '-schemaRoot.description': description,
       '-schemaRoot.additionalProperties': additionalProperties,
+      '-noAdditionalProperties': noAdditionalProperties,
       '-bundle': bundle,
       '-bundleRoot': bundleRoot,
       '-bundleWithoutID': bundleWithoutID,


### PR DESCRIPTION
fixes #346

Tested in https://github.com/tylerrasor/pact-broker-helm/pull/2/commits/4c6b66fc3b70a6d84c45ff056ee864653ba7f357